### PR TITLE
fixes #1 - open png file in binmode

### DIFF
--- a/t/Screenshot.t
+++ b/t/Screenshot.t
@@ -26,6 +26,7 @@ my $screenshot = Selenium::Screenshot->new(%$basic_args);
 
 my $sample_png = $FindBin::Bin . '/sample.png';
 open (my $image_fh, "<", $sample_png) or die 'cannot open: ' . $!;
+binmode $image_fh;
 my $png_string = encode_base64( do{ local $/ = undef; <$image_fh>; } );
 close ($image_fh);
 


### PR DESCRIPTION
On MSWin32 os perl will change CR LF into LF, as CR+LF are parts of the PNG magics the type was not recognized in Imager ( image.c : i_test_format_probe ).
